### PR TITLE
run_jsp_guiオプションをlaunchファイルに追加

### DIFF
--- a/pico_description/launch/display.launch.py
+++ b/pico_description/launch/display.launch.py
@@ -16,11 +16,19 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch_ros.actions import Node
+from launch.actions import DeclareLaunchArgument
+from launch.conditions import IfCondition
 from launch.substitutions import Command
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
 
 
 def generate_launch_description():
+    declare_arg_run_jsp_gui = DeclareLaunchArgument(
+        'run_jsp_gui',
+        default_value='false',
+        description='Set true to run joint_state_publisher_gui node.')
+
     xacro_file = os.path.join(
         get_package_share_directory('pico_description'),
         'urdf',
@@ -41,6 +49,7 @@ def generate_launch_description():
       package="joint_state_publisher_gui",
       executable="joint_state_publisher_gui",
       output="screen",
+      condition=IfCondition(LaunchConfiguration('run_jsp_gui'))
     )
 
     rviz_node = Node(
@@ -52,6 +61,7 @@ def generate_launch_description():
     )
 
     nodes = [
+      declare_arg_run_jsp_gui,
       rviz_node,
       robot_state_pub_node,
       joint_state_pub_gui_node


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

joint_state_publisher_guiノードの起動をON/OFFできるように、
display.launchの引数に`run_jsp_gui`を追加します。

デフォルト値をfalseにしているので、Pi:Coのサンプル実行方法に影響しません。

## この機能を追加した理由

joint_state_publisher_guiが起動していると、Pi:Coのサンプル実行時に「No transform from left_wheel to odom」というエラーが発生します。
このエラーを防ぐため引数を追加します。

![image](https://github.com/rt-net/pico_ros/assets/18494952/267cb276-a78d-4715-ba82-90648ead66f6)


# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
いいえ

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
引数でjoint_state_publisherの起動をON/OFFできることを確認しました。

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
